### PR TITLE
Packable

### DIFF
--- a/Source/Tooling/Templates/README.md
+++ b/Source/Tooling/Templates/README.md
@@ -8,6 +8,7 @@ For authoring **create templates** and whats possible, you can read more [here](
 Go [here](https://docs.microsoft.com/en-us/dotnet/core/tools/custom-templates) for the full article on custom templates.
 
 You can also find more details in the [DotNet Templating Wiki](https://github.com/dotnet/templating/wiki).
+For a templating cheat sheet, go [here](https://queil.net/2018/07/dotnet-templating-cheat-sheet/).
 
 ## Template Parameters & Symbols
 

--- a/Source/Tooling/Templates/templates/aspnet/aspnet.csproj
+++ b/Source/Tooling/Templates/templates/aspnet/aspnet.csproj
@@ -4,6 +4,7 @@
         <ImplicitUsings>true</ImplicitUsings>
         <LangVersion>10</LangVersion>
         <NoWarn>$(NoWarn);CS1591;SA1600</NoWarn>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
     
 	<ItemGroup>


### PR DESCRIPTION
### Added

- Introducing `Aksio.Templates` a `dotnet new` type of template pack. Installed by doing; `dotnet new -i Aksio.Templates`. Also supported by Visual Studio 20xx and Visual Studio for Mac.

