### PR TITLE
Don't force symbols for template pack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create NuGet packages
         if: ${{ steps.release.outputs.should-publish == 'true' }}
-        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.release.outputs.version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.release.outputs.version }}
 
       - name: Push NuGet packages
         if: ${{ steps.release.outputs.should-publish == 'true' }}

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -8,6 +8,9 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <IsPackable>true</IsPackable>
+        <IncludeSymbols>True</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
+        <IncludeSource>True</IncludeSource>
         <RepositoryUrl>https://github.com/aksio-system/Foundation</RepositoryUrl>
         <PackageProjectUrl>https://github.com/aksio-system/Foundation</PackageProjectUrl>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/Tooling/Templates/Aksio.Templates.csproj
+++ b/Source/Tooling/Templates/Aksio.Templates.csproj
@@ -12,6 +12,8 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSource>False</IncludeSource>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
### Added

- Introducing `Aksio.Templates` a `dotnet new` type of template pack. Installed by doing; `dotnet new -i Aksio.Templates`. Also supported by Visual Studio 20xx and Visual Studio for Mac.

