### PR TITLE
Release-templates

### DIFF
--- a/Source/Tooling/Templates/Aksio.Templates.csproj
+++ b/Source/Tooling/Templates/Aksio.Templates.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
     <PackageType>Template</PackageType>
     <PackageVersion>1.0</PackageVersion>
     <PackageId>Aksio.Templates</PackageId>
@@ -8,8 +9,6 @@
     <Authors>Aksio</Authors>
     <Description>Templates to use when creating an application for Aksio.</Description>
     <PackageTags>dotnet-new;templates;aksio</PackageTags>
-
-    <TargetFramework>net6.0</TargetFramework>
 
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeSymbols>False</IncludeSymbols>
@@ -23,5 +22,4 @@
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
     <Compile Remove="**\*" />
   </ItemGroup>
-
 </Project>

--- a/Source/Tooling/Templates/Program.cs
+++ b/Source/Tooling/Templates/Program.cs
@@ -1,2 +1,0 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");


### PR DESCRIPTION
### Added

- Introducing `Aksio.Templates` a `dotnet new` type of template pack. Installed by doing; `dotnet new -i Aksio.Templates`. Also supported by Visual Studio 20xx and Visual Studio for Mac.
