### PR TITLE
Include any assemblies with name starting with Aksio

### DIFF
--- a/Source/Fundamentals/Types/Types.cs
+++ b/Source/Fundamentals/Types/Types.cs
@@ -68,7 +68,8 @@ namespace Aksio.Types
             var entryAssembly = Assembly.GetEntryAssembly();
             var dependencyModel = DependencyContext.Load(entryAssembly);
             var assemblies = dependencyModel.RuntimeLibraries
-                                .Where(_ => _.Type.Equals("project", StringComparison.InvariantCultureIgnoreCase))
+                                .Where(_ => _.Type.Equals("project", StringComparison.InvariantCultureIgnoreCase) ||
+                                            _.Name.StartsWith("Aksio", StringComparison.InvariantCultureIgnoreCase))
                                 .Select(_ => Assembly.Load(_.Name))
                                 .ToArray();
             _assemblies.AddRange(assemblies);


### PR DESCRIPTION
### Fixed

- All Aksio assemblies are now included in type discovery.
