### PR TITLE
Mongodb-hookup

### DIFF
--- a/Documentation/mongodb.md
+++ b/Documentation/mongodb.md
@@ -1,1 +1,55 @@
 # MongoDB
+
+MongoDB is a managed resource. This means that its configuration is managed by the Foundation in code
+and also in the [managed platform running @ Dolittle](https://dolittle.io/docs/platform/requirements/). In addition, MongoDB is also considered a
+[multi-tenant](./tenancy.md). resource which means that there should be one configuration / database
+per [tenant](./tenancy.md).
+
+The Foundation is built with the Dolittle [resource system](https://dolittle.io/docs/platform/requirements/#1-your-application-must-use-the-resource-system) in mind,
+it provides an abstraction for the [resources.json](https://dolittle.io/docs/reference/runtime/configuration/#resourcesjson) file.
+For you as a developer, it has been made very simple by letting you work with the MongoDB C# Driver API only through
+a pre-configured setup for the [IoC Container](./ioc.md).
+
+Usage:
+
+```csharp
+[Route("/api/employees")]
+public class EmployeesController : Controller
+{
+    readonly IMongoDatabase _database;
+
+    public EmployeesController(IMongoDatabase database) => _database = database;
+
+    [HttpGet]
+    public Task<Employee> GetAllEmployees()
+    {
+        var collection = _database.GetCollection<Employee>();
+        return collection.FindAsync(_ => true).ConfigureAwait(false);
+    }
+}
+```
+
+> Important: It is very important that you don't create a singleton and keep the instance around, as you will be handed the
+> correct instance for the tenant in the current context.
+
+The `GetCollection<Employee>()` call is an extension method provided by the Foundation that automatically by convention
+pluralizes the name of the collection and also makes it **camelCase**.
+
+If you need to control the name of the collection, you can use one of the overrides for this:
+
+```csharp
+[Route("/api/employees")]
+public class EmployeesController : Controller
+{
+    readonly IMongoDatabase _database;
+
+    public EmployeesController(IMongoDatabase database) => _database = database;
+
+    [HttpGet]
+    public Task<Employee> GetAllEmployees()
+    {
+        var collection = _database.GetCollection<Employee>("MyEmployees");
+        return collection.FindAsync(_ => true).ConfigureAwait(false);
+    }
+}
+```

--- a/Sample/.dolittle/resources.json
+++ b/Sample/.dolittle/resources.json
@@ -4,7 +4,12 @@
             "servers": [
                 "localhost"
             ],
-            "database": "event_store_aspnetcore"
+            "database": "event_store_sample"
+        },
+        "readModels": {
+            "host": "mongodb://localhost:27017",
+            "database": "read_models_sample",
+            "useSSL": false
         }
     }
 }

--- a/Sample/Employee.cs
+++ b/Sample/Employee.cs
@@ -1,0 +1,4 @@
+namespace Sample
+{
+    public record Employee();
+}

--- a/Sample/MyController.cs
+++ b/Sample/MyController.cs
@@ -1,5 +1,6 @@
 using Aksio.Events.EventLogs;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
 
 namespace Sample
 {
@@ -7,10 +8,12 @@ namespace Sample
     public class MyController : Controller
     {
         readonly IEventLog _eventLog;
+        readonly IMongoDatabase _database;
 
-        public MyController(IEventLog eventLog)
+        public MyController(IEventLog eventLog, IMongoDatabase database)
         {
             _eventLog = eventLog;
+            _database = database;
         }
 
         [HttpGet]

--- a/Sample/MyController.cs
+++ b/Sample/MyController.cs
@@ -19,6 +19,8 @@ namespace Sample
         [HttpGet]
         public async Task Something()
         {
+            var collection = _database.GetCollection<Employee>();
+            await collection.FindAsync(_ => true).ConfigureAwait(false);
             await _eventLog.Append(Guid.NewGuid(), new MyEvent(42)).ConfigureAwait(false);
         }
     }

--- a/Source/Microservices/ApplicationBuilderExtensions.cs
+++ b/Source/Microservices/ApplicationBuilderExtensions.cs
@@ -1,5 +1,5 @@
+using Aksio;
 using Aksio.Execution;
-using Aksio.Microservices;
 
 namespace Microsoft.AspNetCore.Builder
 {

--- a/Source/Microservices/Dolittle/DolittleApplicationBuilderExtensions.cs
+++ b/Source/Microservices/Dolittle/DolittleApplicationBuilderExtensions.cs
@@ -1,5 +1,5 @@
+using Aksio.Dolittle;
 using Aksio.Execution;
-using Aksio.Microservices.Dolittle;
 using Dolittle.SDK;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Source/Microservices/Dolittle/DolittleContainer.cs
+++ b/Source/Microservices/Dolittle/DolittleContainer.cs
@@ -1,7 +1,7 @@
 using Aksio.Execution;
 using ExecutionContext = Dolittle.SDK.Execution.ExecutionContext;
 
-namespace Aksio.Microservices.Dolittle
+namespace Aksio.Dolittle
 {
     /// <summary>
     /// Represents an implementation of <see cref="global::Dolittle.SDK.DependencyInversion.IContainer"/>.

--- a/Source/Microservices/Dolittle/Resources/EventStoreConfiguration.cs
+++ b/Source/Microservices/Dolittle/Resources/EventStoreConfiguration.cs
@@ -1,0 +1,9 @@
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Represents a <see cref="ResourceConfiguration"/> for the Dolittle event store.
+    /// </summary>
+    /// <param name="Servers">MongoDB servers to connect to.</param>
+    /// <param name="Database">Database to use.</param>
+    public record EventStoreConfiguration(string[] Servers, string Database) : ResourceConfiguration;
+}

--- a/Source/Microservices/Dolittle/Resources/IResourceConfigurations.cs
+++ b/Source/Microservices/Dolittle/Resources/IResourceConfigurations.cs
@@ -1,0 +1,21 @@
+using Dolittle.SDK.Tenancy;
+
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Defines a system for working with Dolittle resources.
+    /// </summary>
+    public interface IResourceConfigurations
+    {
+        /// <summary>
+        /// Get a specific resource based on type.
+        /// </summary>
+        /// <param name="tenantId"><see cref="TenantId"/> to get for.</param>
+        /// <typeparam name="TResource">Type of resource to get.</typeparam>
+        /// <returns>Resource instance, if any.</returns>
+        /// <exception cref="MissingResourceConfigurationsForTenant">If no resource configuration exist for tenant.</exception>
+        /// <exception cref="MissingResourceConfigurationOfType">If resource type is unknown.</exception>
+        TResource GetFor<TResource>(TenantId tenantId)
+            where TResource : ResourceConfiguration;
+    }
+}

--- a/Source/Microservices/Dolittle/Resources/MissingResourceConfigurationOfType.cs
+++ b/Source/Microservices/Dolittle/Resources/MissingResourceConfigurationOfType.cs
@@ -1,0 +1,20 @@
+using Dolittle.SDK.Tenancy;
+
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Exception that gets thrown when a resource configuration for a specific type is missing.
+    /// </summary>
+    public class MissingResourceConfigurationOfType : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingResourceConfigurationOfType"/> class.
+        /// </summary>
+        /// <param name="tenantId"><see cref="TenantId"/> the configuration is missing for.</param>
+        /// <param name="type">Type of resource configuration.</param>
+        public MissingResourceConfigurationOfType(TenantId tenantId, Type type)
+            : base($"Missing resource configuration of type '{type.Name}' for tenant '${tenantId}'")
+        {
+        }
+    }
+}

--- a/Source/Microservices/Dolittle/Resources/MissingResourceConfigurationsForTenant.cs
+++ b/Source/Microservices/Dolittle/Resources/MissingResourceConfigurationsForTenant.cs
@@ -1,0 +1,19 @@
+using Dolittle.SDK.Tenancy;
+
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Exception that gets thrown when a resource configuration for a specific tenant is missing.
+    /// </summary>
+    public class MissingResourceConfigurationsForTenant : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingResourceConfigurationsForTenant"/> class.
+        /// </summary>
+        /// <param name="tenantId"><see cref="TenantId"/> that is missing for.</param>
+        public MissingResourceConfigurationsForTenant(TenantId tenantId)
+            : base($"Missing resource configurations for '{tenantId}'")
+        {
+        }
+    }
+}

--- a/Source/Microservices/Dolittle/Resources/MongoDbReadModelsConfiguration.cs
+++ b/Source/Microservices/Dolittle/Resources/MongoDbReadModelsConfiguration.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Represents a <see cref="ResourceConfiguration"/> for MongoDB Read Models.
+    /// </summary>
+    /// <param name="Host">Host to connect to.</param>
+    /// <param name="Database">Database to use.</param>
+    /// <param name="UseSSL">Whether or not to use SSL for connecting.</param>
+    public record MongoDbReadModelsConfiguration(string Host, string Database, bool UseSSL) : ResourceConfiguration;
+}

--- a/Source/Microservices/Dolittle/Resources/ResourceConfiguration.cs
+++ b/Source/Microservices/Dolittle/Resources/ResourceConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Represents a base type for configuration for resources.
+    /// </summary>
+    public record ResourceConfiguration();
+}

--- a/Source/Microservices/Dolittle/Resources/ResourceConfigurations.cs
+++ b/Source/Microservices/Dolittle/Resources/ResourceConfigurations.cs
@@ -1,0 +1,82 @@
+using Dolittle.SDK.Tenancy;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Aksio.Dolittle.Resources
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IResourceConfigurations"/>.
+    /// </summary>
+    public class ResourceConfigurations : IResourceConfigurations
+    {
+        static readonly string _resourcesJsonFilePath = Path.Join(".dolittle", "resources.json");
+
+        readonly Dictionary<TenantId, Dictionary<Type, ResourceConfiguration>> _resourceConfigurationsByTenants = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceConfigurations"/> class.
+        /// </summary>
+        public ResourceConfigurations()
+        {
+            Populate();
+        }
+
+        /// <inheritdoc/>
+        public TResource GetFor<TResource>(TenantId tenantId)
+            where TResource : ResourceConfiguration
+        {
+            ThrowIfMissingResourceConfigurationsForTenant(tenantId);
+
+            var resourceConfigurations = _resourceConfigurationsByTenants[tenantId];
+            ThrowIfMissingResourceConfigurationOfType<TResource>(resourceConfigurations, tenantId);
+
+            return (_resourceConfigurationsByTenants[tenantId][typeof(TResource)] as TResource)!;
+        }
+
+        void Populate()
+        {
+            if (File.Exists(_resourcesJsonFilePath))
+            {
+                var resourcesJson = File.ReadAllText(_resourcesJsonFilePath);
+                var resourcesPerTenant = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, JObject>>>(resourcesJson);
+
+                foreach ((var tenantIdString, var tenantResources) in resourcesPerTenant)
+                {
+                    var tenantId = (TenantId)tenantIdString;
+
+                    var resourceConfigurations = new Dictionary<Type, ResourceConfiguration>();
+                    _resourceConfigurationsByTenants[tenantId] = resourceConfigurations;
+
+                    foreach ((var resourceType, var resourceConfiguration) in tenantResources)
+                    {
+                        switch (resourceType)
+                        {
+                            case "eventStore":
+                                {
+                                    resourceConfigurations[typeof(EventStoreConfiguration)] = resourceConfiguration.ToObject<EventStoreConfiguration>()!;
+                                }
+                                break;
+
+                            case "readModels":
+                                {
+                                    resourceConfigurations[typeof(MongoDbReadModelsConfiguration)] = resourceConfiguration.ToObject<MongoDbReadModelsConfiguration>()!;
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        void ThrowIfMissingResourceConfigurationsForTenant(TenantId tenantId)
+        {
+            if (!_resourceConfigurationsByTenants.ContainsKey(tenantId)) throw new MissingResourceConfigurationsForTenant(tenantId);
+        }
+
+        void ThrowIfMissingResourceConfigurationOfType<TResource>(Dictionary<Type, ResourceConfiguration> resourceConfigurations, TenantId tenantId)
+            where TResource : ResourceConfiguration
+        {
+            if (!resourceConfigurations.ContainsKey(typeof(TResource))) throw new MissingResourceConfigurationOfType(tenantId, typeof(TResource));
+        }
+    }
+}

--- a/Source/Microservices/Execution/ExecutionContextManager.cs
+++ b/Source/Microservices/Execution/ExecutionContextManager.cs
@@ -38,7 +38,7 @@ namespace Aksio.Execution
             _currentExecutionContext.Value = new ExecutionContext(
                 Guid.Empty,
                 tenantId,
-                new Dolittle.SDK.Microservices.Version(1, 0, 0, 0),
+                new global::Dolittle.SDK.Microservices.Version(1, 0, 0, 0),
                 RuntimeEnvironment.IsDevelopment ? Environment.Development : Environment.Production,
                 correlationId,
                 Claims.Empty,

--- a/Source/Microservices/HostBuilderExtensions.cs
+++ b/Source/Microservices/HostBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using Aksio.Microservices;
+using Aksio;
 using Cratis.DependencyInversion;
 using Cratis.Extensions.Dolittle;
 using Cratis.Types;

--- a/Source/Microservices/Internals.cs
+++ b/Source/Microservices/Internals.cs
@@ -1,4 +1,4 @@
-namespace Aksio.Microservices
+namespace Aksio
 {
     /// <summary>
     /// Internal properties.

--- a/Source/Microservices/Microservices.csproj
+++ b/Source/Microservices/Microservices.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+        <PackageReference Include="Humanizer" Version="2.11.10" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Source/Microservices/MongoDB/DatabaseExtensions.cs
+++ b/Source/Microservices/MongoDB/DatabaseExtensions.cs
@@ -1,0 +1,25 @@
+using Cratis.Strings;
+using Humanizer;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Convenience extension methods for <see cref="IMongoDatabase"/>.
+    /// </summary>
+    public static class DatabaseExtensions
+    {
+        /// <summary>
+        /// Get a collection - with name of collection as convention (camelCase of typename).
+        /// </summary>
+        /// <param name="database"><see cref="IMongoDatabase"/> to extend.</param>
+        /// <param name="settings">Optional <see cref="MongoCollectionSettings"/>.</param>
+        /// <typeparam name="T">Type of collection to get.</typeparam>
+        /// <returns>The collection for your type.</returns>
+        public static IMongoCollection<T> GetCollection<T>(this IMongoDatabase database, MongoCollectionSettings? settings = default)
+        {
+            var name = typeof(T).Name.Pluralize();
+            var camelCaseName = name.ToCamelCase();
+            return database.GetCollection<T>(camelCaseName, settings);
+        }
+    }
+}

--- a/Source/Microservices/MongoDB/Module.cs
+++ b/Source/Microservices/MongoDB/Module.cs
@@ -1,0 +1,47 @@
+using Aksio.Execution;
+using Autofac;
+using Cratis.Extensions.MongoDB;
+using Dolittle.SDK.Tenancy;
+using MongoDB.Driver;
+
+namespace Aksio.MongoDB
+{
+    /// <summary>
+    /// Holds the <see cref="Autofac.Module"/> for hooking up bindings for MongoDB.
+    /// </summary>
+    public class Module : Autofac.Module
+    {
+        static readonly Dictionary<TenantId, IMongoDatabase> _mongoDatabaseByTenant = new();
+
+        /// <inheritdoc/>
+        protected override void Load(ContainerBuilder builder)
+        {
+            IContainer? container = null;
+            builder.RegisterBuildCallback(_ => container = _ as IContainer);
+            builder.Register(_ =>
+            {
+                var tenant = container!.Resolve<IExecutionContextManager>().Current.Tenant;
+                if (_mongoDatabaseByTenant.ContainsKey(tenant))
+                {
+                    return _mongoDatabaseByTenant[tenant];
+                }
+
+                var client = container!.Resolve<IMongoDBClientFactory>().Create(MongoUrl.Create("mongodb://localhost:27017"));
+                var database = client.GetDatabase("something");
+                _mongoDatabaseByTenant[tenant] = database;
+                return database;
+
+                /*
+                var config = resourceConfigurations.GetFor<MongoDbReadModelsConfiguration>(tenant);
+                var url = MongoUrl.Create(config.Host);
+                var settings = MongoClientSettings.FromUrl(url);
+                settings.GuidRepresentation = GuidRepresentation.Standard;
+                arguments?.MongoClientSettingsCallback(settings);
+                var client = new MongoClient(settings.Freeze());
+                var database = client.GetDatabase(config.Database);
+                _mongoDatabaseByTenant[tenant] = database;
+                return database;*/
+            }).As<IMongoDatabase>();
+        }
+    }
+}

--- a/Source/Microservices/MongoDB/Module.cs
+++ b/Source/Microservices/MongoDB/Module.cs
@@ -1,6 +1,6 @@
+using Aksio.Dolittle.Resources;
 using Aksio.Execution;
 using Autofac;
-using Cratis.Extensions.MongoDB;
 using Dolittle.SDK.Tenancy;
 using MongoDB.Driver;
 
@@ -26,21 +26,14 @@ namespace Aksio.MongoDB
                     return _mongoDatabaseByTenant[tenant];
                 }
 
-                var client = container!.Resolve<IMongoDBClientFactory>().Create(MongoUrl.Create("mongodb://localhost:27017"));
-                var database = client.GetDatabase("something");
-                _mongoDatabaseByTenant[tenant] = database;
-                return database;
-
-                /*
+                var resourceConfigurations = container!.Resolve<IResourceConfigurations>();
                 var config = resourceConfigurations.GetFor<MongoDbReadModelsConfiguration>(tenant);
                 var url = MongoUrl.Create(config.Host);
                 var settings = MongoClientSettings.FromUrl(url);
-                settings.GuidRepresentation = GuidRepresentation.Standard;
-                arguments?.MongoClientSettingsCallback(settings);
                 var client = new MongoClient(settings.Freeze());
                 var database = client.GetDatabase(config.Database);
                 _mongoDatabaseByTenant[tenant] = database;
-                return database;*/
+                return database;
             }).As<IMongoDatabase>();
         }
     }

--- a/Source/Tooling/Templates/templates/aspnet/Main/.dolittle/resources.json
+++ b/Source/Tooling/Templates/templates/aspnet/Main/.dolittle/resources.json
@@ -5,6 +5,11 @@
                 "localhost"
             ],
             "database": "event_store"
+        },
+        "readModels": {
+            "host": "mongodb://localhost:27017",
+            "database": "read_models",
+            "useSSL": false
         }
     }
 }


### PR DESCRIPTION
### Added

- Adding support for the Dolittle resource system with multi tenancy support.
- Hooking up `IMongoDatabase` to use the resource system.
- Introducing convenience extension method for getting a MongoDB collection and its name resolved from the type, automatically pluralized and camelCased.
