### PR TITLE
Move NoDefaultExclude to .csproj

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Create NuGet packages
         if: ${{ steps.release.outputs.should-publish == 'true' }}
         continue-on-error: true
-        run: dotnet pack -NoDefaultExcludes --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.release.outputs.version }}
+        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.release.outputs.version }}
 
       - name: Push NuGet packages
         if: ${{ steps.release.outputs.should-publish == 'true' }}

--- a/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
+++ b/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
@@ -6,6 +6,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <NoDefaultExcludes>true</NoDefaultExcludes>
    </PropertyGroup>    
 
     <ItemGroup>


### PR DESCRIPTION
### Fixed

- Fixing publish pipeline for NuGet packages. Moving NoDefaultExclude option into .csproj for our template project where it belongs.
