### PR TITLE
Move NoDefaultExcludes to correct project and exclude node_modules from template

### DIFF
--- a/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
+++ b/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
@@ -6,7 +6,6 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <NoDefaultExcludes>true</NoDefaultExcludes>
    </PropertyGroup>    
 
     <ItemGroup>

--- a/Source/Tooling/Templates/Aksio.Templates.csproj
+++ b/Source/Tooling/Templates/Aksio.Templates.csproj
@@ -16,6 +16,8 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+
+    <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
     <PropertyGroup>
@@ -35,7 +37,7 @@
     </Target>
 
     <ItemGroup>
-        <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+        <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;templates\**\node_modules\**" />
         <Compile Remove="**\*" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Excluding `node_modules` from template packaging.