### PR TITLE
Fix-tsconfig-references

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,6 +1,13 @@
-# Templates
+# Getting started
 
-There is a template pack for Aksio projects.
+## Pre requisites
+
+- [.NET Core 6 rc.2 or better](https://dotnet.microsoft.com/download/dotnet/6.0)
+- [Node JS version 16](https://nodejs.org/)
+
+## Install
+
+The project comes with scaffolding templates.
 Install it by simply doing the following from your terminal:
 
 ```shell

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -5,11 +5,11 @@ challenges in one place. On top of that it should also provide tooling when and 
 
 If you want to contribute, please read more [here](./contributing.md).
 
-
 ## Backend
 
 | Topic | Description |
 | ------- | ----------- |
+| [Getting Started](./getting-started.md) | Get started using the scaffolding templates. |
 | [Inversion of Control](./ioc.md) | Why and how inversion of control is setup. |
 | [Tenancy](./tenancy.md) | What is tenancy and how does it work? |
 | [Configuration](./configuration.md) | How the configuration system is setup |
@@ -17,7 +17,6 @@ If you want to contribute, please read more [here](./contributing.md).
 | [Events](./events.md) | How to work with events. |
 | [Event Handlers](./event-handlers.md) | How to work with event handlers. |
 | [MongoDB](./mongodb.md) | How to work with MongoDB. |
-| [Templates](./templates.md) | How you can increase productivity through our packaged templates. |
 | [Third Parties](./third-parties.md) | What third parties comes out of the box, and what they're for. |
 
 ## Frontend

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -5,11 +5,12 @@ challenges in one place. On top of that it should also provide tooling when and 
 
 If you want to contribute, please read more [here](./contributing.md).
 
+To get a quick start, head over to our [getting started](./getting-started.md) section.
+
 ## Backend
 
 | Topic | Description |
 | ------- | ----------- |
-| [Getting Started](./getting-started.md) | Get started using the scaffolding templates. |
 | [Inversion of Control](./ioc.md) | Why and how inversion of control is setup. |
 | [Tenancy](./tenancy.md) | What is tenancy and how does it work? |
 | [Configuration](./configuration.md) | How the configuration system is setup |

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ cross cutting. Its goal is to provide developers with a productivity suite.
 
 Read the [documentation](./Documentation/index.md) for all the details.
 For general guidance on the core values and principles we @ Aksio use, read more [here](https://github.com/aksio-system/Home/blob/main/README.md).
+
+To get a quick start, head over to our [getting started](./Documentation/getting-started.md) section.

--- a/Source/Tooling/Templates/Aksio.Templates.csproj
+++ b/Source/Tooling/Templates/Aksio.Templates.csproj
@@ -25,8 +25,8 @@
         <TemplateDir>$(MSBuildThisFileDirectory)/templates/aspnet</TemplateDir>
     </PropertyGroup>
     <ItemGroup>
-        <FilesToDelete Include="$(TemplateDir)/**/*.cs;$(TemplateDir)/**/*.csproj;$(TemplateDir)/**/*.js;$(TemplateDir)/**/*.ts;$(TemplateDir)/**/*.tsx;$(TemplateDir)/**/*.scss*;$(TemplateDir)/**/*.ejs;$(TemplateDir)/**/*.json" Exclude="$(TemplateDir)/Web/package.json;$(TemplateDir)/updateAksioReferences.js;$(TemplateDir)/.vscode/**/*;$(TemplateDir)/.template.config/template.json"/>
-        <FilesToCopy Include="$(Sample)/**/*.cs;$(Sample)/**/*.csproj;;$(Sample)/**/*.js;$(Sample)/**/*.ts;$(Sample)/**/*.tsx;$(Sample)/**/*.scss*;$(Sample)/**/*.ejs;$(Sample)/**/*.json" Exclude="$(Sample)/Web/package.json;$(Sample)/Web/node_modules/**/*"/>
+        <FilesToDelete Include="$(TemplateDir)/**/*.cs;$(TemplateDir)/**/*.csproj;$(TemplateDir)/**/*.js;$(TemplateDir)/**/*.ts;$(TemplateDir)/**/*.tsx;$(TemplateDir)/**/*.scss*;$(TemplateDir)/**/*.ejs;$(TemplateDir)/**/*.json" Exclude="$(TemplateDir)/Web/package.json;$(TemplateDir)/Web/tsconfig.json;$(TemplateDir)/updateAksioReferences.js;$(TemplateDir)/.vscode/**/*;$(TemplateDir)/.template.config/template.json"/>
+        <FilesToCopy Include="$(Sample)/**/*.cs;$(Sample)/**/*.csproj;;$(Sample)/**/*.js;$(Sample)/**/*.ts;$(Sample)/**/*.tsx;$(Sample)/**/*.scss*;$(Sample)/**/*.ejs;$(Sample)/**/*.json" Exclude="$(Sample)/Web/package.json;$(Sample)/Web/tsconfig.json;$(Sample)/Web/node_modules/**/*"/>
     </ItemGroup>
 
     <Target Name="CopyFiles" BeforeTargets="Build">

--- a/Source/Tooling/Templates/templates/aspnet/.template.config/template.json
+++ b/Source/Tooling/Templates/templates/aspnet/.template.config/template.json
@@ -93,6 +93,19 @@
             }
         },
         {
+            "description": "Instructions for starting Dolittle",
+            "actionId": "AC1156F7-BB77-4DB8-B28F-24EEBCCA1E5C",
+            "manualInstructions": [
+                {
+                    "text": "You'll need the Dolittle Runtime to run (if using ARM64 (Apple M based CPUs)) - change image to: dolittle/runtime:latest-arm64-development"
+                }
+            ],
+            "args": {
+                "executable": "docker",
+                "args": "run -d -p 50052:50052 -p 50053:50053 -p 27017:27017 dolittle/runtime:latest-development"
+            }
+        },       
+        {
             "description": "Instructions for starting backend",
             "actionId": "AC1156F7-BB77-4DB8-B28F-24EEBCCA1E5C",
             "manualInstructions": [

--- a/Source/Tooling/Templates/templates/aspnet/Web/tsconfig.json
+++ b/Source/Tooling/Templates/templates/aspnet/Web/tsconfig.json
@@ -39,11 +39,5 @@
         "**/dist"
     ],
     "references": [
-        {
-            "path": "../../Source/Frontend/tsconfig.json"
-        },
-        {
-            "path": "../../Source/TypeScript/tsconfig.json"
-        }
     ]
 }


### PR DESCRIPTION
### Fixed

- Removed TypeScript project refernece only relevant when running the sample from the repo not from the template.
- Changed documentation to focus on getting started, rather than templates and made it the first topic.