### PR TITLE
Fixing API alias configuration - move into compiler options

### DIFF
--- a/Sample/Web/tsconfig.json
+++ b/Sample/Web/tsconfig.json
@@ -33,12 +33,12 @@
         "assumeChangesOnlyAffectDirectDependencies": true,
         "alwaysStrict": true,
         "preserveConstEnums": true,
-        "newLine": "lf"
-    },
-    "paths": {
-        "API/*": [
-            "./API/*"
-        ]
+        "newLine": "lf",
+        "paths": {
+            "API/*": [
+                "./API/*"
+            ]
+        },
     },
     "exclude": [
         "**/dist"

--- a/Source/Tooling/Templates/templates/aspnet/Web/tsconfig.json
+++ b/Source/Tooling/Templates/templates/aspnet/Web/tsconfig.json
@@ -33,16 +33,15 @@
         "assumeChangesOnlyAffectDirectDependencies": true,
         "alwaysStrict": true,
         "preserveConstEnums": true,
-        "newLine": "lf"
-    },
-    "paths": {
-        "API/*": [
-            "./API/*"
-        ]
+        "newLine": "lf",
+        "paths": {
+            "API/*": [
+                "./API/*"
+            ]
+        },
     },
     "exclude": [
         "**/dist"
     ],
-    "references": [
-    ]
+    "references": []
 }


### PR DESCRIPTION
### Fixed

- Fixed API alias configuration for TypeScript for Sample + Template - moved into the compiler options + fixed casing.
