### PR TITLE
Separating out and adding retries for connection + cleanup when React effect is out of scope

### DIFF
--- a/Source/Frontend/queries/IObservableQueryFor.ts
+++ b/Source/Frontend/queries/IObservableQueryFor.ts
@@ -1,5 +1,5 @@
-import { QueryResult } from './QueryResult';
 import Handlebars from 'handlebars';
+import { ObservableQuerySubscription } from './ObservableQuerySubscription';
 
 /**
  * The delegate type representing the callback of result from the server.
@@ -22,7 +22,7 @@ export interface IObservableQueryFor<TDataType, TArguments = {}> {
      * Subscribe to the query. This will create a subscription onto the server.
      * @param {OnNextResult} callback The callback that will receive result from the server.
      * @param [args] Optional arguments for the query - depends on whether or not the query needs arguments.
-     * @returns {QueryResult} for the model
+     * @returns {ObservableQuerySubscription<TDataType>}.
      */
-    subscribe(callback: OnNextResult, args?: TArguments): void;
+    subscribe(callback: OnNextResult, args?: TArguments): ObservableQuerySubscription<TDataType>;
 }

--- a/Source/Frontend/queries/ObservableQueryConnection.ts
+++ b/Source/Frontend/queries/ObservableQueryConnection.ts
@@ -1,0 +1,74 @@
+export type DataReceived<TDataType> = (data: TDataType) => void;
+
+/**
+ * Represents the connection for an observable query.
+ */
+export class ObservableQueryConnection<TDataType> {
+
+    private _socket!: WebSocket;
+    private _disconnected = false;
+
+    /**
+     * Initializes a new instance of the {@link ObservableQueryConnection<TDataType>} class.
+     * @param {string} _route The relative route to use - relative to the current origin and protocol.
+     */
+    constructor(private readonly _route: string) {
+    }
+
+    /**
+     * Connect to a specific route.
+     * @param {DataReceived<TDataType> dataReceived Callback that will receive the data.
+     */
+    connect(dataReceived: DataReceived<TDataType>) {
+        const secure = document.location.protocol.indexOf('https') === 0;
+        const url = `${secure ? 'wss' : 'ws'}://${document.location.host}${this._route}`;
+        let timeToWait = 500;
+        const timeExponent = 500;
+        const retries = 100;
+        let currentAttempt = 0;
+
+        const connectSocket = () => {
+            const retry = () => {
+                currentAttempt++;
+                if (currentAttempt > retries) {
+                    console.log(`Attempted ${retries} retries for route '${this._route}'. Abandoning.`);
+                    return;
+                }
+                console.log(`Attempting to reconnect for '${this._route}' (#${currentAttempt})`);
+
+                setTimeout(connectSocket, timeToWait);
+                timeToWait += (timeExponent * currentAttempt);
+            };
+
+            this._socket = new WebSocket(url);
+            this._socket.onopen = (ev) => {
+                console.log(`Connection for '${this._route}' established`);
+                timeToWait = 500;
+                currentAttempt = 0;
+            };
+            this._socket.onclose = (ev) => {
+                if (this._disconnected) return;
+                console.log(`Unexpected connection closed for route '${this._route}`);
+                retry();
+            };
+            this._socket.onerror = (error) => {
+                console.log(`Error with connection for '${this._route} - ${error}`);
+                retry();
+            };
+            this._socket.onmessage = (ev) => {
+                dataReceived(JSON.parse(ev.data));
+            };
+        };
+
+        connectSocket();
+    }
+
+    /**
+     * Disconnect the connection.
+     */
+    disconnect() {
+        console.log(`Disconnecting '${this._route}'`);
+        this._disconnected = true;
+        this._socket?.close();
+    }
+}

--- a/Source/Frontend/queries/ObservableQuerySubscription.ts
+++ b/Source/Frontend/queries/ObservableQuerySubscription.ts
@@ -1,0 +1,23 @@
+import { ObservableQueryConnection } from './ObservableQueryConnection';
+
+
+/**
+ * Represents a subscription for an observable query.
+ */
+export class ObservableQuerySubscription<TDataType> {
+
+    /**
+     * Initializes a new instance of the {@link ObservableQuerySubscription} class.
+     * @param {ObservableQueryConnection<TDataType> _connection The connection to use.
+     */
+    constructor(private _connection: ObservableQueryConnection<TDataType>) {
+    }
+
+    /**
+     * Unsubscribe subscription.
+     */
+    unsubscribe() {
+        this._connection.disconnect();
+        this._connection = undefined!;
+    }
+}

--- a/Source/Frontend/queries/useObservableQuery.ts
+++ b/Source/Frontend/queries/useObservableQuery.ts
@@ -14,18 +14,18 @@ import { useState, useEffect } from 'react';
 export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResult<TDataType>] {
     const queryInstance = new query() as TQuery;
     const [result, setResult] = useState<QueryResult<TDataType>>(new QueryResult(queryInstance.defaultValue, true));
-    const queryExecutor = (async (args?: TArguments) => {
+
+    useEffect(() => {
         if (queryInstance.requiresArguments && !args) {
             console.log(`Warning: Query '${query.name}' requires arguments. Will not perform the query.`);
             return;
         }
-        queryInstance.subscribe(_ => {
+
+        const subscription = queryInstance.subscribe(_ => {
             setResult(_ as unknown as QueryResult<TDataType>);
         }, args);
-    });
 
-    useEffect(() => {
-        queryExecutor(args);
+        return () => subscription.unsubscribe();
     }, []);
 
     return [result];


### PR DESCRIPTION
### Fixed

- WebSockets will now retry with a backoff strategy if connection is either errored or closed unexpectedly.
- Cleaning up query subscriptions when a query gets out of React rendering scope.
