### PR TITLE
Merge pull request #40 from aksio-system:robustify-websockets

### DIFF
--- a/Documentation/frontend/proxy-generation.md
+++ b/Documentation/frontend/proxy-generation.md
@@ -96,3 +96,12 @@ files for the **Domain** and **Read** you would then add a dependency to the NuG
 ```
 
 The generator will maintain the folder structure from the source files while generating based on the namespaces of the files.
+
+If you want to not let the type and namespace be the convention for the target folder, you can use the route of the controller
+as the folder instead by adding the following property:
+
+```xml
+<PropertyGroup>
+    <AksioUseRouteAsPath>true</AksioUseRouteAsPath>
+</PropertyGroup>
+```

--- a/Sample/Directory.Build.props
+++ b/Sample/Directory.Build.props
@@ -7,6 +7,7 @@
         <NoWarn>$(NoWarn);CS0012;RCS1090;CA2007</NoWarn>    <!-- ConfigureAwait requirement, https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
 
         <AksioProxyOutput>$(MSBuildThisFileDirectory)/Web/API</AksioProxyOutput>
+        <AksioUseRouteAsPath>false</AksioUseRouteAsPath>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)../Source/Tooling/ProxyGenerator/build/Aksio.ProxyGenerator.props"/>

--- a/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
+++ b/Source/Tooling/ProxyGenerator/ProxyGenerator.csproj
@@ -8,9 +8,7 @@
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
    </PropertyGroup>    
 
-    <ItemGroup>
-        <CompilerVisibleProperty Include="AksioProxyOutput" />
-    </ItemGroup>
+   <Import Project="./build/Aksio.ProxyGenerator.props"/>
 
     <ItemGroup>
         <PackageReference Include="handlebars.net" Version="2.0.9" GeneratePathProperty="true" PrivateAssets="all" />

--- a/Source/Tooling/ProxyGenerator/build/Aksio.ProxyGenerator.props
+++ b/Source/Tooling/ProxyGenerator/build/Aksio.ProxyGenerator.props
@@ -1,5 +1,6 @@
 <Project>
     <ItemGroup>
         <CompilerVisibleProperty Include="AksioProxyOutput"/>
+        <CompilerVisibleProperty Include="AksioUseRouteAsPath"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

If you want to not let the type and namespace be the convention for the target folder, you can use the route of the controller as the folder instead by adding the following property to your **.csproj** file:

```xml
<PropertyGroup>
    <AksioUseRouteAsPath>true</AksioUseRouteAsPath>
</PropertyGroup>
```

The path from the route will be appended to the value of `<AksioProxyOutput/>`. It will strip away any prefix of `/api` in the route.

### Added

- Convention for outputting to a folder based on the `Controller` route specified in the `[Route]` attribute.