### PR TITLE
Enumerable-fix

### DIFF
--- a/Source/Tooling/ProxyGenerator/Diagnostics.cs
+++ b/Source/Tooling/ProxyGenerator/Diagnostics.cs
@@ -16,7 +16,7 @@ namespace Aksio.ProxyGenerator
                 "Missing output path",
                 "Missing output path for generating proxies to. Add <AksioProxyOutput/> to your .csproj file. Will not output proxies.",
                 "Generation",
-                DiagnosticSeverity.Warning,
+                DiagnosticSeverity.Info,
                 true),
             default);
 

--- a/Source/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
+++ b/Source/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
@@ -16,7 +16,6 @@ namespace Aksio.ProxyGenerator.Syntax
         static readonly Dictionary<string, TargetType> _primitiveTypeMap = new()
         {
             { typeof(string).FullName!, new("string") },
-            { "System.String"", new("string") },
             { typeof(short).FullName!, new("number") },
             { typeof(int).FullName!, new("number") },
             { typeof(long).FullName!, new("number") },
@@ -135,6 +134,8 @@ namespace Aksio.ProxyGenerator.Syntax
         /// <returns>True if it is enumerable, false if not.</returns>
         public static bool IsEnumerable(this ITypeSymbol symbol)
         {
+            if (symbol is IArrayTypeSymbol) return true;
+            if (symbol.IsKnownType()) return false;
             return symbol.AllInterfaces.Any(_ => _.ToDisplayString() == "System.Collections.IEnumerable");
         }
 
@@ -150,6 +151,11 @@ namespace Aksio.ProxyGenerator.Syntax
 
         static string GetTypeName(ITypeSymbol symbol)
         {
+            if (symbol is IArrayTypeSymbol arrayTypeSymbol)
+            {
+                symbol = arrayTypeSymbol.ElementType;
+            }
+
             return $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.Name}";
         }
     }


### PR DESCRIPTION
### Fixed

- String properties does not become `string[]` in the proxy generated TypeScript files.
- Adding support for arrays and leveraging the element type in the Roslyn API.
