### PR TITLE
Dotnet-template-fixes

### DIFF
--- a/Sample/Web/API/Accounts/Debit/AccountId.ts
+++ b/Sample/Web/API/Accounts/Debit/AccountId.ts
@@ -3,12 +3,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-export type AccountHolder = {
-    firstName: string;
-    lastName: string;
-    socialSecurityNumber: string;
-    address: string;
-    city: string;
-    postalCode: string;
-    country: string;
+export type AccountId = {
 };

--- a/Sample/Web/API/Accounts/Debit/AccountName.ts
+++ b/Sample/Web/API/Accounts/Debit/AccountName.ts
@@ -3,12 +3,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-export type AccountHolder = {
-    firstName: string;
-    lastName: string;
-    socialSecurityNumber: string;
-    address: string;
-    city: string;
-    postalCode: string;
-    country: string;
+export type AccountName = {
 };

--- a/Sample/Web/API/Accounts/Debit/ClientObservable.ts
+++ b/Sample/Web/API/Accounts/Debit/ClientObservable.ts
@@ -3,12 +3,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-export type AccountHolder = {
-    firstName: string;
-    lastName: string;
-    socialSecurityNumber: string;
-    address: string;
-    city: string;
-    postalCode: string;
-    country: string;
+export type ClientObservable = {
 };

--- a/Sample/Web/API/Accounts/Debit/PersonId.ts
+++ b/Sample/Web/API/Accounts/Debit/PersonId.ts
@@ -3,12 +3,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-export type AccountHolder = {
-    firstName: string;
-    lastName: string;
-    socialSecurityNumber: string;
-    address: string;
-    city: string;
-    postalCode: string;
-    country: string;
+export type PersonId = {
 };

--- a/Source/Tooling/Templates/templates/aspnet/AksioMicroserviceTemplate.sln
+++ b/Source/Tooling/Templates/templates/aspnet/AksioMicroserviceTemplate.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Specs", "Read.Specs\Re
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Main", "Main\Main.csproj", "{0B4F6A2C-7B7D-4FC2-8936-AFAB6429E93B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration", "Integration\Integration.csproj", "{E262BF50-3F90-492D-BA39-EDD4144AB974}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,5 +56,9 @@ Global
 		{0B4F6A2C-7B7D-4FC2-8936-AFAB6429E93B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B4F6A2C-7B7D-4FC2-8936-AFAB6429E93B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B4F6A2C-7B7D-4FC2-8936-AFAB6429E93B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E262BF50-3F90-492D-BA39-EDD4144AB974}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E262BF50-3F90-492D-BA39-EDD4144AB974}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E262BF50-3F90-492D-BA39-EDD4144AB974}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E262BF50-3F90-492D-BA39-EDD4144AB974}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Source/Tooling/Templates/templates/aspnet/Directory.Build.props
+++ b/Source/Tooling/Templates/templates/aspnet/Directory.Build.props
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Aksio.Defaults" Version="1.1.18" />
+        <PackageReference Include="Aksio.Integration" Version="1.7.2" />
         <PackageReference Include="Aksio.Microservices" Version="1.7.2" />
         <!--#if (IncludeWeb) -->
         <PackageReference Include="Aksio.ProxyGenerator" Version="1.7.2" />

--- a/Source/Tooling/Templates/templates/aspnet/updateAksioReferences.js
+++ b/Source/Tooling/Templates/templates/aspnet/updateAksioReferences.js
@@ -26,16 +26,19 @@ try {
             req.end();
         });
     }
-  
+
     async function handleNuGetPackages() {
         const file = path.join(__dirname, 'Directory.Build.props');
-    
+
         console.log(`Working on file ${file}`);
-    
+
         const content = fs.readFileSync(file).toString();
         const nugetPackages = [
             'Aksio.Defaults',
             'Aksio.Microservices',
+            'Aksio.CQRS',
+            'Aksio.CQRS.MongoDB',
+            'Aksio.Integration',
             'Aksio.ProxyGenerator'
         ];
 
@@ -57,6 +60,7 @@ try {
 
     async function handleNpmPackages() {
         const file = path.join(__dirname, 'Web', 'package.json');
+        if (!fs.existsSync(file)) return;
 
         console.log(`Working on file ${file}`);
 
@@ -64,7 +68,7 @@ try {
         const npmPackages = [
             '@aksio/frontend'
         ];
-        
+
         let result = content;
 
         for (const package of npmPackages) {


### PR DESCRIPTION
### Fixed

- Integration project is now part of the solution file in the template.
- If creating a project without Web, it does not crash anymore during creation if package.json is not there.
- Adding Aksio.Integration as reference in the template.
