### PR TITLE
Proxy-generator-eagerness

### DIFF
--- a/Sample/Web/API/AccountHolders/AccountHolder.ts
+++ b/Sample/Web/API/AccountHolders/AccountHolder.ts
@@ -4,11 +4,11 @@
 
 
 export type AccountHolder = {
-    firstName: string[];
-    lastName: string[];
-    socialSecurityNumber: string[];
-    address: string[];
-    city: string[];
-    postalCode: string[];
-    country: string[];
+    firstName: string;
+    lastName: string;
+    socialSecurityNumber: string;
+    address: string;
+    city: string;
+    postalCode: string;
+    country: string;
 };

--- a/Source/Tooling/ProxyGenerator/SourceGenerator.cs
+++ b/Source/Tooling/ProxyGenerator/SourceGenerator.cs
@@ -20,6 +20,8 @@ namespace Aksio.ProxyGenerator
         /// <inheritdoc/>
         public void Execute(GeneratorExecutionContext context)
         {
+            if (context.Compilation.GetDiagnostics().Any(_ => _.Severity == DiagnosticSeverity.Error)) return;
+
             var receiver = context.SyntaxReceiver as SyntaxReceiver;
             context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.rootnamespace", out var rootNamespace);
             if (!context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.aksioproxyoutput", out var outputFolder))
@@ -78,7 +80,7 @@ namespace Aksio.ProxyGenerator
                 if (renderedTemplate != default)
                 {
                     var file = Path.Combine(targetFolder, $"{typeName}.ts");
-                    File.WriteAllText(file, renderedTemplate);
+                    WriteFile(file, renderedTemplate);
                 }
             }
         }
@@ -135,7 +137,7 @@ namespace Aksio.ProxyGenerator
                         TemplateTypes.Query(queryDescriptor);
                     if (renderedTemplate != default)
                     {
-                        File.WriteAllText(targetFile, renderedTemplate);
+                        WriteFile(targetFile, renderedTemplate);
                     }
                 }
             }
@@ -232,7 +234,7 @@ namespace Aksio.ProxyGenerator
             if (renderedTemplate != default)
             {
                 Directory.CreateDirectory(targetFolder);
-                File.WriteAllText(targetFile, renderedTemplate);
+                WriteFile(targetFile, renderedTemplate);
             }
         }
 
@@ -280,6 +282,12 @@ namespace Aksio.ProxyGenerator
             }
 
             return folder;
+        }
+
+        static void WriteFile(string file, string content)
+        {
+            if (string.IsNullOrEmpty(Path.GetFileNameWithoutExtension(file))) return;
+            File.WriteAllText(file, content);
         }
     }
 }


### PR DESCRIPTION
## Summary

One of the optimizations done in .NET Core 3 and forward was that the compiler processes where kept around as a build server (`dotnet build-server`). The Roslyn compiler can then be incremental in memory. With a source generator running, this can become very eager as it is actually running as part of the whole infrastructure continuously as you type in the editor. To avoid generating files when the code isn't really compiling, we needed to make sure we're not in errored state.

### Fixed

- Exit the source generator if there are any diagnostics with error in severity.
- If a filename without extension is empty - do not write the file.
